### PR TITLE
BUG: use numpy.intp_t, not numpy.int_t, for indexing

### DIFF
--- a/src/gvar/_gvarcore.pyx
+++ b/src/gvar/_gvarcore.pyx
@@ -679,7 +679,7 @@ class GVarFactory:
         cdef GVar gd
         cdef numpy.ndarray[numpy.double_t,ndim=1] d
         cdef numpy.ndarray[numpy.double_t,ndim=1] d_v
-        cdef numpy.ndarray[numpy.int_t,ndim=1] d_idx
+        cdef numpy.ndarray[numpy.intp_t,ndim=1] d_idx
         
         if len(args)==2:
             # (x,xsdev) or (xarray,sdev-array) or (xarray,cov) 


### PR DESCRIPTION
Fixes test errors on win-amd64, e.g.

```
======================================================================
ERROR: test_cmp (test_gvar.test_gvar1)
x==y x!=y x>y x<y
----------------------------------------------------------------------
Traceback (most recent call last):
  File
"D:\downloads\files_P\python\packages\lsqfit\tests\test_gvar.py",
line 248, in test_cmp
    y = gvar(x.mean,x.der,x.cov)    # y.der == x.der
  File "_gvarcore.pyx", line 810, in
gvar._gvarcore.GVarFactory.__call__ (src/gvar\_gvarcore.c:13528)
ValueError: Buffer dtype mismatch, expected 'int_t' but got 'long long'

======================================================================
ERROR: test_construct_gvar (test_gvar.test_gvar2)
```
