### PR TITLE
Multifitter empbayes

### DIFF
--- a/src/lsqfit/_extras.py
+++ b/src/lsqfit/_extras.py
@@ -1426,6 +1426,9 @@ class MultiFitter(object):
         self.set(**oldargs)
         return self.fit
 
+    def empbayes_fit(self, z0, fitargs, chained=False, **minargs):
+        return empbayes_fit(z0=z0, fitargs=fitargs, multifitter=self, chained=chained, **minargs)
+
     @staticmethod
     def _compile_models(models):
         """ Convert ``models`` into a list of tasks.

--- a/src/lsqfit/_extras.py
+++ b/src/lsqfit/_extras.py
@@ -162,7 +162,7 @@ def empbayes_fit(z0, fitargs, models=None, chained=False, **minargs):
         if models is None:
             fit = lsqfit.nonlinear_fit(**args)
         elif chained:
-            fit = fitter.lsqfit(**args)
+            fit = fitter.chained_lsqfit(**args)
         else:
             fit = fitter.lsqfit(**args)
         if numpy.isnan(fit.logGBF):
@@ -183,6 +183,8 @@ def empbayes_fit(z0, fitargs, models=None, chained=False, **minargs):
         args['p0'] = save['lastp0']
     if models is None:
         return lsqfit.nonlinear_fit(**args), z
+    elif chained:
+        return fitter.chained_lsqfit(**args), z
     else:
         return fitter.lsqfit(**args), z
 

--- a/src/lsqfit/_extras.py
+++ b/src/lsqfit/_extras.py
@@ -109,12 +109,14 @@ def empbayes_fit(z0, fitargs, multifitter=None, chained=False, **minargs):
     Args:
         z0 (number, array or dict): Starting point for search.
         fitargs (callable): Function of ``z`` that returns a
-            dictionary ``args`` containing the :class:`lsqfit.nonlinear_fit`
+            dictionary ``args`` containing the :class:`lsqfit.nonlinear_fit`,
+            :class:`MultiFitter.lsqfit`, or :class:`MultiFitter.chained_lsqfit`
             arguments corresponding to ``z``. ``z`` should have
             the same layout (number, array or dictionary) as ``z0``.
             ``fitargs(z)`` can instead return a tuple ``(args, plausibility)``,
             where ``args`` is again the dictionary for
-            :class:`lsqfit.nonlinear_fit`. ``plausibility`` is the logarithm
+            :class:`lsqfit.nonlinear_fit`,  :class:`MultiFitter.lsqfit`, 
+            or :class:`MultiFitter.chained_lsqfit`. ``plausibility`` is the logarithm
             of the *a priori* probabilitiy that ``z`` is sensible. When
             ``plausibility`` is provided, :func:`lsqfit.empbayes_fit`
             maximizes the sum ``logGBF + plausibility``. Specifying
@@ -126,7 +128,8 @@ def empbayes_fit(z0, fitargs, multifitter=None, chained=False, **minargs):
 
     Returns:
         A tuple containing the best fit (object of type
-        :class:`lsqfit.nonlinear_fit`) and the
+        :class:`lsqfit.nonlinear_fit`, :class:`MultiFitter.lsqfit`, 
+        or :class:`MultiFitter.chained_lsqfit`) and the
         optimal value for parameter ``z``.
     """
     save = dict(lastz=None, lastp0=None)
@@ -134,17 +137,17 @@ def empbayes_fit(z0, fitargs, multifitter=None, chained=False, **minargs):
         # z is a dictionary
         if not isinstance(z0, gvar.BufferDict):
             z0 = gvar.BufferDict(z0)
-        z0buf = z0.buf
+        z0buf = numpy.array(z0.buf, dtype=float)
         def convert(zbuf):
             return gvar.BufferDict(z0, buf=zbuf)
     elif numpy.shape(z0) == ():
         # z is a number
-        z0buf = numpy.array([z0])
+        z0buf = numpy.array([z0], dtype=float)
         def convert(zbuf):
             return zbuf[0]
     else:
         # z is an array
-        z0 = numpy.asarray(z0)
+        z0 = numpy.asarray(z0, dtype=float)
         z0buf = z0
         def convert(zbuf):
             return zbuf

--- a/src/lsqfit/_extras.py
+++ b/src/lsqfit/_extras.py
@@ -33,11 +33,11 @@ except ImportError:
 
 def empbayes_fit(z0, fitargs, multifitter=None, chained=False, **minargs):
     """ Return fit and ``z`` corresponding to the fit that maximizes
-    ``logGBF``. When ``models`` is specified, this perform a 
-    simultaneous fit using the MultiFitter class and returns the result
+    ``logGBF``. When ``multifitter`` is specified, this perform a 
+    simultaneous/chained fit using the MultiFitter class and returns the result
     of either ``MultiFitter(models=models).chained_lsqfit(**args)``
     (when ``chained=True``) or ``MultiFitter(models=models).lsqfit(**args)``
-    (``chained=False``). If no models are specified, returns
+    (when ``chained=False``). If no models are specified, returns
     ``lsqfit.nonlinear_fit(**fitargs(z))`` 
 
     This function maximizes the logarithm of the Bayes Factor from
@@ -1430,6 +1430,41 @@ class MultiFitter(object):
         return self.fit
 
     def empbayes_fit(self, z0, fitargs, chained=False, **minargs):
+        """ Return fit and ``z`` corresponding to the fit that maximizes
+        ``logGBF``, performing either a simultaneous (``chained=False``) 
+        or chained fit (``chained=True``).
+
+        This function maximizes the logarithm of the Bayes Factor from
+        fit  ``MultiFitter.lsqfit(**fitargs(z))``  or 
+        ``MultiFitter.chained_lsqfit(**fitargs(z))`` by varying ``z``,
+        starting at ``z0``. The fit is redone for each value of ``z``
+        that is tried in order to determine ``logGBF``.
+
+        Args:
+            z0 (number, array or dict): Starting point for search.
+            fitargs (callable): Function of ``z`` that returns a
+                dictionary ``args`` containing the 
+                :class:`MultiFitter.lsqfit` or :class:`MultiFitter.chained_lsqfit`
+                arguments corresponding to ``z``. ``z`` should have
+                the same layout (number, array or dictionary) as ``z0``.
+                ``fitargs(z)`` can instead return a tuple ``(args, plausibility)``,
+                where ``args`` is again the dictionary for
+                :class:`MultiFitter.lsqfit`, or :class:`MultiFitter.chained_lsqfit`.
+                ``plausibility`` is the logarithm of the *a priori* 
+                probabilitiy that ``z`` is sensible. When
+                ``plausibility`` is provided, :func:`lsqfit.empbayes_fit`
+                maximizes the sum ``logGBF + plausibility``. Specifying
+                ``plausibility`` is a way of steering selections away from
+                completely implausible values for ``z``.
+            minargs (dict): Optional argument dictionary, passed on to
+                :class:`lsqfit.gsl_multiminex` (or
+                :class:`lsqfit.scipy_multiminex`), which finds the minimum.
+
+        Returns:
+            A tuple containing the best fit (object of type
+            :class:`MultiFitter.lsqfit` or :class:`MultiFitter.chained_lsqfit`) 
+            and the optimal value for parameter ``z``.
+        """
         return empbayes_fit(z0=z0, fitargs=fitargs, multifitter=self, chained=chained, **minargs)
 
     @staticmethod


### PR DESCRIPTION
Addresses #5 and #6 . I've updated some of the docstring for `empbayes_fit` and `MultiFitter.empbayes_fit`, albeit perhaps not fully.

With respect to the example in #6, either of the following works:

```python
fit, z = lsqfit.empbayes_fit(z0={'intercept' : 0.5, 'slope' : 1.0}, fitargs=fitargs, multifitter=fitter, chained=True)
```
or 
```python
fit, z = fitter.empbayes_fit(z0={'intercept' :  0.5, 'slope' : 1.0}, fitargs=fitargs, chained=True)
```

Thus 

```python
class Linear(lsqfit.MultiFitterModel):
    def __init__(self, datatag, x, intercept, slope):
        super(Linear, self).__init__(datatag)
        # the independent variable
        self.x = np.array(x)
        # keys used to find the intercept and slope in a parameter dictionary
        self.intercept = intercept
        self.slope = slope

    def fitfcn(self, p):
        try:
            return p[self.intercept] + p[self.slope] * self.x
        except KeyError:
            # slope parameter marginalized/omitted
            return len(self.x) * [p[self.intercept]]

    def buildprior(self, prior, mopt=None):
        " Extract the model's parameters from prior. "
        newprior = {}
        newprior[self.intercept] = prior[self.intercept]
        if mopt is None:
            # slope parameter marginalized/omitted if mopt is not None
            newprior[self.slope] = prior[self.slope]
        return newprior

    def builddata(self, data):
        " Extract the model's fit data from data. "
        return data[self.datatag]

data = gv.gvar(dict(
    d1=['1.154(10)', '2.107(16)', '3.042(22)', '3.978(29)'],
    d2=['0.692(10)', '1.196(16)', '1.657(22)', '2.189(29)'],
    d3=['0.107(10)', '0.030(16)', '-0.027(22)', '-0.149(29)'],
    d4=['0.002(10)', '-0.197(16)', '-0.382(22)', '-0.627(29)'],
    ))

models = [
   Linear('d1', x=[1,2,3,4], intercept='a', slope='s1'),
   Linear('d2', x=[1,2,3,4], intercept='a', slope='s2'),
   Linear('d3', x=[1,2,3,4], intercept='a', slope='s3'),
   Linear('d4', x=[1,2,3,4], intercept='a', slope='s4'),
   ]

def fitargs(z):
    # Force prior width 0.01 <= z <= 100
    for key in z:
        if z[key] <= 0.01:
            z[key] = 0.01
        elif z[key] >= 100.0:
            z[key] = 100
            
    prior = gv.BufferDict()
    prior['a'] = gv.gvar(0, z['intercept'])
    prior['s1'] = gv.gvar(0, z['slope'])
    prior['s2'] = gv.gvar(0, z['slope'])
    prior['s3'] = gv.gvar(0, z['slope'])
    prior['s4'] = gv.gvar(0, z['slope'])

    print(z)
    return dict(data=data, prior=prior)

fitter = lsqfit.MultiFitter(models=models)
#fit, z = lsqfit.empbayes_fit(z0={'intercept' : 0.5, 'slope' : 1.0}, fitargs=fitargs, multifitter=fitter, chained=True)
fit, z = fitter.empbayes_fit(z0={'intercept' : 1, 'slope' : 1}, fitargs=fitargs, chained=True, step=0.2)
print(fit)
```
returns
```python
{'intercept': 1.0,'slope': 1.0}
{'intercept': 1.2,'slope': 1.0}
{'intercept': 1.0,'slope': 1.2}
{'intercept': 1.2000000000000002,'slope': 0.8000000000000003}
{'intercept': 1.2999999999999998,'slope': 0.5999999999999996}
{'intercept': 1.0999999999999996,'slope': 0.5999999999999996}
{'intercept': 1.049999999999999,'slope': 0.39999999999999947}
{'intercept': 1.3999999999999995,'slope': 0.1999999999999993}
{'intercept': 1.0999999999999999,'slope': 0.7999999999999998}
{'intercept': 1.2999999999999998,'slope': 0.39999999999999925}
{'intercept': 1.15,'slope': 0.6999999999999997}
{'intercept': 1.2499999999999996,'slope': 0.4999999999999991}
{'intercept': 1.0499999999999994,'slope': 0.49999999999999867}
{'intercept': 0.9249999999999998,'slope': 0.4499999999999984}
{'intercept': 0.7749999999999999,'slope': 0.5499999999999985}
{'intercept': 0.5375000000000005,'slope': 0.5749999999999984}
{'intercept': 0.3625000000000007,'slope': 0.42499999999999694}
{'intercept': 0.01,'slope': 0.33749999999999547}
{'intercept': 0.01,'slope': 0.5499999999999967}
{'intercept': 0.6875000000000002,'slope': 0.474999999999998}
{'intercept': 0.2125000000000008,'slope': 0.524999999999997}
{'intercept': 0.01,'slope': 0.5499999999999967}
{'intercept': 0.037500000000000755,'slope': 0.3749999999999951}
{'intercept': 0.4125000000000006,'slope': 0.5249999999999976}
{'intercept': 0.2625000000000004,'slope': 0.6249999999999973}
{'intercept': 0.06250000000000033,'slope': 0.6249999999999962}
{'intercept': 0.3250000000000005,'slope': 0.5499999999999973}
{'intercept': 0.15000000000000047,'slope': 0.5999999999999968}
{'intercept': 0.19375000000000048,'slope': 0.5874999999999968}
{'intercept': 0.1437500000000007,'slope': 0.48749999999999627}
{'intercept': 0.23281250000000048,'slope': 0.5906249999999971}
{'intercept': 0.17343750000000047,'slope': 0.5218749999999963}
{'intercept': 0.18828125000000048,'slope': 0.5390624999999964}
{'intercept': 0.20703125000000056,'slope': 0.476562499999996}
{'intercept': 0.1970703125000005,'slope': 0.5597656249999966}
{'intercept': 0.1728515624999999,'slope': 0.5738281249999955}
{'intercept': 0.20258789062500057,'slope': 0.5372070312499966}
{'intercept': 0.21137695312500032,'slope': 0.5579101562499962}
{'intercept': 0.20560302734375036,'slope': 0.5531982421874964}
{'intercept': 0.21112060546875022,'slope': 0.5306396484374958}
{'intercept': 0.20058288574218794,'slope': 0.5524841308593714}
{'intercept': 0.197567749023438,'slope': 0.5364929199218713}
{'intercept': 0.20359420776367226,'slope': 0.5490219116210902}
{'intercept': 0.20158920288085952,'slope': 0.5642990112304647}
{'intercept': 0.20233821868896532,'slope': 0.5439800262451135}
{'intercept': 0.20534954071044959,'slope': 0.5405178070068322}
{'intercept': 0.20177454948425336,'slope': 0.5494925498962366}
{'intercept': 0.2005185604095463,'slope': 0.54445066452026}
{'intercept': 0.1989807367324834,'slope': 0.5421650409698451}
{'intercept': 0.2010822296142582,'slope': 0.5389381408691367}
{'intercept': 0.20160146951675456,'slope': 0.5468539476394616}
{'intercept': 0.19978181123733546,'slope': 0.5473245859146081}
{'intercept': 0.20169911682605784,'slope': 0.5448161661624872}
{'intercept': 0.20061620771884947,'slope': 0.5424128830432857}
{'intercept': 0.20135515406727827,'slope': 0.5457436814904176}
{'intercept': 0.2025357104837897,'slope': 0.546109183132645}
{'intercept': 0.20102284792810715,'slope': 0.5448652941733563}
{'intercept': 0.20067888516932741,'slope': 0.545792809501287}
{'intercept': 0.20093394308351,'slope': 0.545548648666587}
{'intercept': 0.201266249222681,'slope': 0.5464270359836485}
{'intercept': 0.2010836982517506,'slope': 0.5452557296259293}
{'intercept': 0.2006624872679822,'slope': 0.545060696802099}
{'intercept': 0.20118198736745424,'slope': 0.545572935318338}
{'intercept': 0.2013317425356947,'slope': 0.5452800162776803}
{'intercept': 0.20103339294655617,'slope': 0.5454814905693603}
{'intercept': 0.20093510383085234,'slope': 0.5451642848769518}
{'intercept': 0.20112026648330378,'slope': 0.5454707727079914}
{'intercept': 0.20106996117810916,'slope': 0.5456965336514226}
{'intercept': 0.20108026398334022,'slope': 0.5453659306323027}
{'intercept': 0.20108026398334022,'slope': 0.5453659306323027}
Least Square Fit:
  chi2/dof [dof] = 0.73 [16]    Q = 0.77    logGBF = 20.937

Parameters:
              a    0.2009 (78)      [  0.00 (20) ]  
             s1    0.9437 (81)      [  0.00 (55) ]  *
             s2    0.4906 (64)      [  0.00 (55) ]  
             s3   -0.0839 (57)      [  0.00 (55) ]  
             s4   -0.2000 (53)      [  0.00 (55) ]  

Settings:
  svdcut/n = 1e-12/0    tol = (1e-08,1e-10,1e-10)    (itns/time = 13/0.0)
  fitter = chained fit    

Chained Fits:
  chi2/dof [dof]       Q     logGBF  svd-n    itns/time  fit            
------------------------------------------------------------------------
         1.1 [4]    0.35     2.7184      0        4/0.0  d1
        0.71 [4]    0.58     5.7276      0        4/0.0  d2
        0.65 [4]    0.63     5.9966      0        4/0.0  d3
        0.43 [4]    0.79      6.494      0        1/0.0  d4
------------------------------------------------------------------------
       0.73 [16]    0.77     20.937      0       13/0.0  all

```