### PR TITLE
Documentation: (fit->gv).fmt_{values,errorbudget}

### DIFF
--- a/doc/source/overview.rst
+++ b/doc/source/overview.rst
@@ -661,8 +661,8 @@ Our complete Python program is, therefore::
             }
         inputs = {'E':fit.prior['E'], 'a':fit.prior['a'], 'y':y}
         print('================= Error Budget Analysis')
-        print(fit.fmt_values(outputs))
-        print(fit.fmt_errorbudget(outputs,inputs))
+        print(gv.fmt_values(outputs))
+        print(gv.fmt_errorbudget(outputs,inputs))
 
     def fcn(x, p):                      # function used to fit x, y data
         a = p['a']                      # array of a[i]s
@@ -1403,8 +1403,8 @@ Our complete code, therefore, is::
             'E prior':prior['E'], 'a prior':prior['a'],
             'svd cut':fit.correction,
             }
-        print(fit.fmt_values(outputs))
-        print(fit.fmt_errorbudget(outputs, inputs))
+        print(gv.fmt_values(outputs))
+        print(gv.fmt_errorbudget(outputs, inputs))
 
     def fcn(x,p):
         a = p['a']       # array of a[i]s


### PR DESCRIPTION
Encountered a hiccup while reproducing some of the examples in the
documentation.

The issue was that rather than `fmt_values` and `fmt_errorbudget` being
called from the gvar module via `gv.` it was being called as an
attribute of the resulting `nonlinear_fit` object `fit`.